### PR TITLE
Handle custom error styles

### DIFF
--- a/cypress/e2e/all_specs.cy.js
+++ b/cypress/e2e/all_specs.cy.js
@@ -1,11 +1,14 @@
-// import "./events/input/presence.cy";
-// import "./events/input/length.cy";
-// import "./events/input/numericality.cy";
-// import "./events/input/email.cy";
-// import "./events/input/multiple_validations.cy";
+import "./events/input/presence.cy";
+import "./events/input/length.cy";
+import "./events/input/numericality.cy";
+import "./events/input/email.cy";
+import "./events/input/multiple_validations.cy";
 
-// import "./events/blur/presence.cy";
-// import "./events/blur/length.cy";
-// import "./events/blur/numericality.cy";
-// import "./events/blur/email.cy";
-// import "./events/blur/multiple_validations.cy";
+import "./events/blur/presence.cy";
+import "./events/blur/length.cy";
+import "./events/blur/numericality.cy";
+import "./events/blur/email.cy";
+import "./events/blur/multiple_validations.cy";
+
+import "./styles/css.cy";
+import "./styles/classes.cy";

--- a/cypress/e2e/styles/classes.cy.js
+++ b/cypress/e2e/styles/classes.cy.js
@@ -1,0 +1,25 @@
+describe("styles/classes", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:8080/");
+  });
+
+  it(`It applys default css styles if none are passed as data-errors-styles-css attribute`, () => {
+    cy.get(`input[data-validate-email][data-field="customClasses"]`)
+      .type("abc")
+      .clear();
+
+    cy.get(
+      'div[data-input-validator-target="errors"][data-field="customClasses"]'
+    ).within(() => {
+      cy.get(`div[error="email"]`)
+        .should("exist")
+        .should("not.have.attr", "style");
+      cy.get(`div[error="email"]`)
+        .should("exist")
+        .should("have.attr", "class")
+        .and("include", "text-lg")
+        .and("include", "text-purple-600")
+        .and("include", "font-bold");
+    });
+  });
+});

--- a/cypress/e2e/styles/css.cy.js
+++ b/cypress/e2e/styles/css.cy.js
@@ -1,0 +1,24 @@
+describe("styles/css", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:8080/");
+  });
+
+  it(`It applys default css styles if none are passed as data-errors-styles-css attribute`, () => {
+    cy.get(`input[data-validate-email][data-field="customCSS"]`)
+      .type("abc")
+      .clear();
+
+    cy.get(
+      'div[data-input-validator-target="errors"][data-field="customCSS"]'
+    ).within(() => {
+      cy.get(`div[error="email"]`)
+        .should("exist")
+        .should("not.have.attr", "class")
+      cy.get(`div[error="email"]`)
+        .should("exist")
+        .should("have.attr", "style")
+        .and("include", "font-size: 14px")
+        .and("include", "color: blue");
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             <div
               data-input-validator-target="errors"
               data-field="fullName"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
           <!-- presence end-->
 
@@ -66,7 +66,7 @@
             <div
               data-input-validator-target="errors"
               data-field="userName"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
           <!-- length end-->
 
@@ -83,7 +83,7 @@
             <div
               data-input-validator-target="errors"
               data-field="currency"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
           <!-- numericality end-->
 
@@ -100,7 +100,7 @@
             <div
               data-input-validator-target="errors"
               data-field="emailField"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
           <!-- email end-->
         </div>
@@ -124,7 +124,7 @@
             <div
               data-input-validator-target="errors"
               data-field="multiple"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
         </div>
         <!-- section end-->
@@ -144,8 +144,48 @@
             <div
               data-input-validator-target="errors"
               data-field="railsModel"
-              class="text-sm text-red-500"></div>
+              class=""></div>
           </div>
+        </div>
+        <!-- section end-->
+        <!-- section start -->
+        <div class="w-full max-w-xs flex flex-col justify-center items-center">
+          <h1 class="text-xl text-center font-bold">Custom error styles</h1>
+          <!-- email start-->
+          <div class="flex flex-col justify-center items-start mb-2 w-full">
+            <label for="fullName">CSS (font-size: 14px; color: blue)</label>
+            <input 
+              type="text" 
+              data-input-validator-target="textField" 
+              data-field='customCSS'
+              data-validate-email
+              class="w-full"
+            >
+            <div
+              data-input-validator-target="errors"
+              data-field="customCSS"
+              data-errors-styles-css="font-size: 14px; color: blue;"
+              class=""></div>
+          </div>
+          <!-- email end-->
+
+          <!-- email start-->
+          <div class="flex flex-col justify-center items-start mb-2 w-full">
+            <label for="fullName">Classes (text-lg text-purple-600 font-bold)</label>
+            <input 
+              type="text" 
+              data-input-validator-target="textField" 
+              data-field='customClasses'
+              data-validate-email
+              class="w-full"
+            >
+            <div
+              data-input-validator-target="errors"
+              data-field="customClasses"
+              data-errors-styles-class="text-lg text-purple-600 font-bold"
+              class=""></div>
+          </div>
+          <!-- email end-->
         </div>
         <!-- section end-->
       </div>

--- a/src/input_validator.js
+++ b/src/input_validator.js
@@ -19,10 +19,6 @@ export default class extends Controller {
   validateMultiple(target, errors) {}
 
   handleValidations(target, value, errors) {
-    // if (target.hasAttribute("data-validations")) {
-    //   this.validateMultiple(value, errors);
-    // }
-
     if (
       target.hasAttribute("data-validate-presence") &&
       target.getAttribute("data-validate-presence") != "false"
@@ -57,7 +53,25 @@ export default class extends Controller {
     }
   }
 
-  validateInput({ target, target: { value} }) {
+  errorElement(errorsContainer, error) {
+    let styles = "font-size: 14px; color: red";
+    let classes;
+
+    if (errorsContainer.hasAttribute("data-errors-styles-css")) {
+      styles = errorsContainer.getAttribute("data-errors-styles-css");
+    }
+
+    if (errorsContainer.hasAttribute("data-errors-styles-class")) {
+      styles = null;
+      classes = errorsContainer.getAttribute("data-errors-styles-class");
+    }
+
+    return `<div error="${error.type}" ${
+      styles ? "style='" + styles + "'" : ""
+    } ${classes ? "class='" + classes + "'" : ""} >${error.message}</div>`;
+  }
+
+  validateInput({ target, target: { value } }) {
     let field = target.getAttribute("data-field");
     let [errorsContainer] = this.errorsTargets.filter(
       (item) => item.getAttribute("data-field") == field
@@ -71,7 +85,7 @@ export default class extends Controller {
 
     if (errors.length) {
       errors.forEach((error) => {
-        errorsContainer.innerHTML += `<div error="${error.type}" class="text-sm text-red-500">${error.message}</div>`;
+        errorsContainer.innerHTML += this.errorElement(errorsContainer, error);
         errorsContainer.style.visibility = "visible";
       });
     } else {


### PR DESCRIPTION
Adds ability to set custom errors styles via CSS or Classes.

Adding `data-errors-styles-css="...styles"` or `data-errors-styles-class="...classes"` attribute to a data-errors-target element will override the default style attribute on rendered errors.

Example CSS:
```html
<div data-input-validator-target="errors"
     data-field="customCSS"
     data-errors-styles-css="font-size: 14px; color: blue;">
</div>
```

Example Tailwind classes:
```html
<div data-input-validator-target="errors"
     data-field="customClasses"
     data-errors-styles-class="text-lg text-purple-600 font-bold">
</div>
```
